### PR TITLE
Improve instructions related to BeeAI

### DIFF
--- a/docs/Introduction_acp_beeai/lab-3/README.md
+++ b/docs/Introduction_acp_beeai/lab-3/README.md
@@ -66,10 +66,10 @@ You should see both the triage output (structured data about the ticket) and the
 ### 6. Clean Up
 
 1. Stop the ACP agent servers using `Ctrl + C` or exiting the terminal where it is running.
-2. Stop the platform by running this command in your terminal:
+2. Clean up the platform by running this command in your terminal:
 
     ```shell
-    beeai platform stop
+    beeai platform delete
     ```
 
 ## Congratulations! You've completed the Introduction to ACP + BeeAI Workshop.

--- a/docs/Introduction_acp_beeai/pre-work/README.md
+++ b/docs/Introduction_acp_beeai/pre-work/README.md
@@ -10,16 +10,6 @@ logo: images/ibm-blue-background.png
 
 ### Prerequisites to get started with ACP
 
-#### Python >=3.11
-
-- Go to [python.org/downloads](https://www.python.org/downloads/)
-- Download the version for your operating system (Windows, macOS, or Linux)
-
-    !!! important
-        During installation, make sure to check the box that says `Add Python to PATH` or manually add it if you skip this step
-
-- To verify installation type `python --version`
-
 #### Visual Studio Code (Recommended)
 
 - You can use any IDE, but this workshop assumes you're using [VS Code](https://code.visualstudio.com/Download)
@@ -27,8 +17,8 @@ logo: images/ibm-blue-background.png
 
 #### uv
 
-- uv is the recommended package and environment manager for this workshop, but you can use uv, pip, or another package manager if you're more comfortable with them.
-- If you're unfamiliar with uv, check out [this uv primer](https://agentcommunicationprotocol.dev/introduction/uv-primer) for installation instructions
+- `uv` is the recommended Python package and environment manager for this workshop
+- If you're unfamiliar with `uv`, check out [this uv primer](https://agentcommunicationprotocol.dev/introduction/uv-primer) for installation instructions
 
 #### API Key
 
@@ -36,53 +26,13 @@ logo: images/ibm-blue-background.png
 
 ## BeeAI Platform
 
-### Prerequisites to get started with BeeAI Platform
+Install BeeAI platform using the [installation instructions in the documentation](https://docs.beeai.dev/introduction/installation). Don't forget to run `beeai platform start` to start the platform prior to running the examples.
 
-- [Homebrew](https://brew.sh/) (for macOS or Linux)
-
-    If you don't already have Homebrew installed, run the following command in your terminal and follow the instructions to update your shell environment:
-
-    ```shell
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    ```
-
-- [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) (for Windows users)
-
-    See [Windows WSL2 setup instructions](https://docs.beeai.dev/introduction/installation#windows-wsl2-setup-instructions)
-
-- BeeAI Installation
-
-    !!! note
-        If using Windows, open WSL2 by right-clicking the Start menu, selecting a terminal (e.g., PowerShell or Windows Terminal), and typing the `wsl` command. From there, run all the following installation commands inside the WSL shell, not the Windows shell.
-
-    Install BeeAI using Homebrew:
-
-    ```shell
-    brew install i-am-bee/beeai/beeai
-    ```
+Already installed BeeAI in the past? Be sure to update it to the latest version according to the instructions in the documentation.
 
 ## Workshop Specific Requirements
 
-1. Start the BeeAI background service:
-
-    ```shell
-    beeai platform start
-    ```
-
-2. Configure your LLM provider for the BeeAI Platform
-
-    !!! note
-        You will need your OpenAI or Groq API key available
-
-    ```shell
-    beeai env setup
-    ```
-3. Verify that installation is working properly
-    ```shell
-        beeai list
-    ```
-
-4. In a separate terminal, get the workshop code:
+1. Get the workshop code:
 
     Option A: Clone with Git (Recommended):
 
@@ -93,7 +43,7 @@ logo: images/ibm-blue-background.png
     Option B: Download ZIP:
     If you're not comfortable with Git, [download the ZIP file](https://github.com/IBM/beeai-workshop/archive/refs/heads/main.zip) and extract it to your desired location.
 
-5. Navigate to the workshop folder and open in VS Code:
+2. Navigate to the workshop folder and open in VS Code:
 
     ```shell
     cd beeai-workshop/intro_acp_beeai
@@ -105,7 +55,7 @@ logo: images/ibm-blue-background.png
 
     **Alternative:** You can also open VS Code first, then use "File > Open Folder" to navigate to and select the `beeai-workshop/intro_acp_beeai` folder.
 
-6. Create a .env file based on the env.template file at the intro_acp_beeai directory level. Uncomment out either the OpenAI API Key or the Groq API key and add your own api.
+3. Create a .env file based on the env.template file at the intro_acp_beeai directory level. Uncomment out either the OpenAI API Key or the Groq API key and add your own api.
 
     ```shell
     cp env.template .env
@@ -113,12 +63,3 @@ logo: images/ibm-blue-background.png
 
     !!! note
         For OpenAI you just need the API Key, for Groq you need to uncomment all 3 environment variables but only need to modify the API Key.
-
-### Already have BeeAI installed? Update and restart it
-
-```shell
-brew services stop
-brew uninstall arize-phoenix
-brew upgrade beeai
-beeai platform start --set phoenix.enabled=true
-```

--- a/docs/Introduction_acp_beeai/uninstall_troubleshooting/README.md
+++ b/docs/Introduction_acp_beeai/uninstall_troubleshooting/README.md
@@ -10,27 +10,7 @@ logo: images/ibm-blue-background.png
 
 ### Complete Uninstall
 
-To completely remove BeeAI from your system:
-
-1. Stop the BeeAI platform service:
-
-    ```shell
-    beeai platform stop
-    ```
-
-2. Uninstall BeeAI using Homebrew:
-
-    ```shell
-    brew uninstall beeai
-    ```
-
-### Uninstall Dependencies
-
-If you also want to remove related dependencies that were installed:
-
-```shell
-brew uninstall arize-phoenix
-```
+To completely remove BeeAI from your system, follow the "Uninstall" section in the [BeeAI documentation installation guide](https://docs.beeai.dev/introduction/installation) depending on how you installed BeeAI.
 
 ## Getting Help
 
@@ -61,7 +41,7 @@ You can access comprehensive CLI documentation directly from your terminal:
     ```shell
     lsof -i :8000
     ```
-2. Kill the process if needed:
+2. Kill the process if needed, substituting the number in the "PID" column:
     ```shell
     kill -9 <PID>
     ```
@@ -77,7 +57,7 @@ You can access comprehensive CLI documentation directly from your terminal:
 **Solutions:**
 1. Try stopping and restarting:
     ```shell
-    beeai platform stop
+    beeai platform delete
     beeai platform start
     ```
 
@@ -98,15 +78,11 @@ You can access comprehensive CLI documentation directly from your terminal:
 **Problem:** `uv sync` fails or Python dependency errors
 
 **Solutions:**
-1. Ensure you're using Python >=3.11:
-    ```shell
-    python --version
-    ```
-2. Try clearing UV cache:
+1. Try clearing `uv` cache:
     ```shell
     uv cache clean
     ```
-3. Reinstall dependencies:
+2. Reinstall dependencies:
     ```shell
     uv sync --reinstall
     ```
@@ -116,10 +92,14 @@ You can access comprehensive CLI documentation directly from your terminal:
 **Problem:** BeeAI UI doesn't load in browser
 
 **Solutions:**
-1. Try a different browser or incognito/private mode
-2. Clear browser cache and cookies
-3. Ensure the BeeAI platform is running:
+1. Upgrade BeeAI to the latest version
+2. Run this command, which will check the platform and env:
     ```shell
+    beeai ui
+    ```
+3. Recreate your BeeAI platform instance and try again:
+    ```shell
+    beeai platform delete
     beeai platform start
     beeai ui
     ```
@@ -144,21 +124,7 @@ You can access comprehensive CLI documentation directly from your terminal:
 
 ## Reset and Clean Installation
 
-If you're experiencing persistent issues, try a clean reinstall:
-
-1. **Complete cleanup:**
-    ```shell
-    beeai platform stop
-    brew uninstall beeai
-    brew uninstall arize-phoenix
-    ```
-
-2. **Fresh installation:**
-    ```shell
-    brew install i-am-bee/beeai/beeai
-    beeai platform start
-    beeai env setup
-    ```
+If you're experiencing persistent issues, try a clean reinstall -- follow the "Uninstall" section and then the "Install" section in the [BeeAI installation documentation](https://docs.beeai.dev/introduction/installation).
 
 ## Getting Additional Support
 


### PR DESCRIPTION
- Remove Python installation section, that's actually not needed (`uv` will download and manage Python automatically)
- Remove BeeAI installation instructions and replace with a link to the official docs
  - reasoning: it's easier to keep up to date, we update the docs when things change, also the instructions are more detailed (e.g. for Windows users)
- Fixed / cleared some troubleshooting steps