### PR TITLE
Changed docs to include Redis Cloud as an option

### DIFF
--- a/docs/beeai_fw__tavily_redis/pre-work/README.md
+++ b/docs/beeai_fw__tavily_redis/pre-work/README.md
@@ -84,6 +84,8 @@ We'll be using Redis for local vector storage.
 
 - Follow the [official installation instructions](https://redis.io/docs/latest/operate/oss_and_stack/install/)
 
+- Or use Redis Cloud by creating a [free account](https://redis.io/try-free/)
+
 ---
 
 ## You're Ready

--- a/docs/beeai_fw__tavily_redis/setup/README.md
+++ b/docs/beeai_fw__tavily_redis/setup/README.md
@@ -40,11 +40,14 @@ Alternatively, you can open VS Code first and use `File > Open Folder` to naviga
 ## Set Up Environment Variables
 
 Create a `.env` file based on the existing `env.template` at the `beeai_fw_tavily_redis` directory level.  
-Add your **Tavily** key and optionally your **OpenAI** key to this file.
 
 ```bash
 cp env.template .env
 ```
+
+Add your **Tavily** key and optionally your **OpenAI** key to this `.env` file.
+
+**If using Redis Cloud** - Also include `REDIS_URL` from the dashboard
 
 ---
 


### PR DESCRIPTION
On both the retriever and db populate script for Redis,
`REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")`
is used, so if the user just includes a `REDIS_URL` on their .env from their free cloud account, then we use the Redis Cloud instead of the local Redis server without having to change anything else.

We might need to include this as an option since docker is the *only* way to install Redis on windows machines.
Docker desktop is not supported by IBM and prompting them to use rancher or other alternatives and set everything up might take away time from focusing on the actual workshop. 

It is as simple as clicking connect on their Redis cloud dashboard and copying the URL. And this workshop uses <3MB of 30MB of free storage. 

<img width="2560" height="1276" alt="image" src="https://github.com/user-attachments/assets/2ed1ee28-ed73-42ce-bff5-567cea7b0b97" />
